### PR TITLE
Remove Event.setCancelled(false) calls

### DIFF
--- a/src/me/lim_bo56/lnpp/menus/listeners/LobbyMenuListener.java
+++ b/src/me/lim_bo56/lnpp/menus/listeners/LobbyMenuListener.java
@@ -86,8 +86,6 @@ public class LobbyMenuListener extends AllStrings implements Listener {
     	
     	if(MainPreferences.getInstance().Stacker.contains(d) && d.getPassenger() != null) {
     		e.setCancelled(true);
-    	} else {
-    		e.setCancelled(false);
     	}
     }
 	
@@ -121,7 +119,6 @@ public class LobbyMenuListener extends AllStrings implements Listener {
 			        p.sendMessage(AllStrings.getInstance().ChatDisabled);
 		   } else if (MainPreferences.getInstance().Chat.contains(p)) {
 			   e.getRecipients().add(p);
-			   e.setCancelled(false);
 		   }
 		 }
 	 }


### PR DESCRIPTION
Event.setCancelled(false) has the ability to mess with other plugins and what they do, essentially bypassing other plugins and enforcing your plugin's decision.

This must not happen, because other plugins still need to work.

This pull request fixes it.
