### PR TITLE
Add integer setting values

### DIFF
--- a/playersettings-api/src/main/java/me/limbo56/playersettings/api/Setting.java
+++ b/playersettings-api/src/main/java/me/limbo56/playersettings/api/Setting.java
@@ -36,5 +36,12 @@ public interface Setting {
      *
      * @return Default value
      */
-    boolean getDefaultValue();
+    int getDefaultValue();
+
+    /**
+     * Gets the maximum value for the setting
+     *
+     * @return Maximum value
+     */
+    int getMaxValue();
 }

--- a/playersettings-api/src/main/java/me/limbo56/playersettings/api/SettingCallback.java
+++ b/playersettings-api/src/main/java/me/limbo56/playersettings/api/SettingCallback.java
@@ -10,5 +10,5 @@ public interface SettingCallback {
      * @param player   Player who it was changed for
      * @param newValue The new value of the setting
      */
-    void notifyChange(Setting setting, Player player, boolean newValue);
+    void notifyChange(Setting setting, Player player, int newValue);
 }

--- a/playersettings-api/src/main/java/me/limbo56/playersettings/api/SettingUpdateEvent.java
+++ b/playersettings-api/src/main/java/me/limbo56/playersettings/api/SettingUpdateEvent.java
@@ -20,14 +20,18 @@ public class SettingUpdateEvent extends Event {
     private Player player;
     private Setting setting;
     @Accessors(fluent = true)
-    private boolean getValue;
+    private int getValue;
 
     public static HandlerList getHandlerList() {
         return HANDLERS;
     }
 
-    public boolean getPreviousValue() {
-        return !getValue();
+    // fixme what if it is toggled instead??
+    public int getPreviousValue() {
+        int previous = getValue() - 1;
+        if (previous < 0)
+            return setting.getMaxValue();
+        return previous;
     }
 
     @Override

--- a/playersettings-api/src/main/java/me/limbo56/playersettings/api/SettingWatcher.java
+++ b/playersettings-api/src/main/java/me/limbo56/playersettings/api/SettingWatcher.java
@@ -11,7 +11,7 @@ public interface SettingWatcher {
      * @param setting Setting where value is stored
      * @return The value of the setting
      */
-    boolean getValue(Setting setting);
+    int getValue(Setting setting);
 
     /**
      * Sets the value of the setting provided
@@ -20,7 +20,7 @@ public interface SettingWatcher {
      * @param value   Value to be set
      * @param silent  If true, it changes the value without activating the side effect
      */
-    void setValue(Setting setting, boolean value, boolean silent);
+    void setValue(Setting setting, int value, boolean silent);
 
     /**
      * Gets the callback map

--- a/playersettings-api/src/main/java/me/limbo56/playersettings/api/SimpleSetting.java
+++ b/playersettings-api/src/main/java/me/limbo56/playersettings/api/SimpleSetting.java
@@ -14,10 +14,12 @@ public class SimpleSetting implements Setting {
     private int page;
     private int slot;
     @Getter(AccessLevel.NONE)
-    private boolean defaultValue;
+    private int defaultValue;
+    private int maxValue;
 
     @Override
-    public boolean getDefaultValue() {
+    public int getDefaultValue() {
         return defaultValue;
     }
+
 }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/command/subcommand/GetCommand.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/command/subcommand/GetCommand.java
@@ -28,18 +28,18 @@ public class GetCommand extends CommandBase {
         }
 
         SPlayer sPlayer = plugin.getSPlayer(player.getUniqueId());
-        boolean settingValue = sPlayer.getSettingWatcher().getValue(setting);
-        String settingName = setting.getItem().getItemMeta().getDisplayName();
+        int settingValue = sPlayer.getSettingWatcher().getValue(setting);
 
         PlayerUtils.sendConfigMessage(player, "commands.getSetting", message ->
-                fillPlaceholders(message, settingName, settingValue)
+                fillPlaceholders(message, setting, settingValue)
         );
     }
 
-    private String fillPlaceholders(String message, String settingName, boolean settingValue) {
-        String value = String.valueOf(settingValue)
-                .replaceAll("true", "on")
-                .replaceAll("false", "off");
+    private String fillPlaceholders(String message, Setting setting, int settingValue) {
+        String value = String.valueOf(settingValue);
+        if (setting.getMaxValue() == 1)
+            value = settingValue == 1 ? "on" : "off";
+        String settingName = setting.getItem().getItemMeta().getDisplayName();
         return message.replaceAll("%name%", ChatColor.stripColor(settingName))
                 .replaceAll("%value%", value);
     }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/command/subcommand/SetCommand.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/command/subcommand/SetCommand.java
@@ -12,6 +12,8 @@ import org.bukkit.Sound;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import static me.limbo56.playersettings.utils.ParseUtils.parseInt;
+
 public class SetCommand extends CommandBase {
     public SetCommand() {
         super(3, "set", "<setting> <value>", "Sets the value of a specified setting", null);
@@ -31,7 +33,9 @@ public class SetCommand extends CommandBase {
             return;
         }
 
-        if (!value.equals("on") && !value.equals("off")) {
+        Integer valueInt = parseInt(value);
+
+        if (valueInt == null || valueInt > setting.getMaxValue() || valueInt < -setting.getMaxValue()) {
             PlayerUtils.sendConfigMessage(player, "commands.acceptedValues");
             return;
         }
@@ -40,7 +44,7 @@ public class SetCommand extends CommandBase {
         SettingWatcher settingWatcher = sPlayer.getSettingWatcher();
         Sound pianoSound = XSound.BLOCK_NOTE_BLOCK_HARP.parseSound();
 
-        settingWatcher.setValue(setting, value.equals("on"), false);
+        settingWatcher.setValue(setting, valueInt, false);
         player.playSound(player.getLocation(), pianoSound, 1, value.equals("on") ? 1 : -99);
 
         // Send message change message if it's enabled

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/command/subcommand/SetCommand.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/command/subcommand/SetCommand.java
@@ -12,6 +12,8 @@ import org.bukkit.Sound;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.util.function.Function;
+
 import static me.limbo56.playersettings.utils.ParseUtils.parseInt;
 
 public class SetCommand extends CommandBase {
@@ -35,8 +37,9 @@ public class SetCommand extends CommandBase {
 
         Integer valueInt = parseInt(value);
 
-        if (valueInt == null || valueInt > setting.getMaxValue() || valueInt < -setting.getMaxValue()) {
-            PlayerUtils.sendConfigMessage(player, "commands.acceptedValues");
+        if (valueInt == null) {
+            Function<String, String> modifier = s -> s.replaceAll("%max%", String.valueOf(setting.getMaxValue()));
+            PlayerUtils.sendConfigMessage(player, "commands.acceptedValues", modifier);
             return;
         }
 

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/configuration/ItemsConfiguration.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/configuration/ItemsConfiguration.java
@@ -63,6 +63,8 @@ public class ItemsConfiguration extends YmlConfiguration {
         set(rawName + ".name", itemStack.getItemMeta().getDisplayName().replaceAll("§", "&"));
         set(rawName + ".material", itemStack.getType() + data);
         set(rawName + ".default", setting.getDefaultValue());
+        if (setting.getMaxValue() > 1)
+            set(rawName + ".max", setting.getMaxValue());
         set(rawName + ".amount", itemStack.getAmount());
         set(rawName + ".lore", Collections.replaceAll(itemStack.getItemMeta().getLore(), "§", "&"));
         set(rawName + ".page", setting.getPage());

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/configuration/ItemsConfiguration.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/configuration/ItemsConfiguration.java
@@ -67,6 +67,7 @@ public class ItemsConfiguration extends YmlConfiguration {
         set(rawName + ".lore", Collections.replaceAll(itemStack.getItemMeta().getLore(), "§", "&"));
         set(rawName + ".page", setting.getPage());
         set(rawName + ".slot", setting.getSlot());
+        set(rawName + ".executeOnJoin", true);
         save();
     }
 }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/configuration/MessagesConfiguration.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/configuration/MessagesConfiguration.java
@@ -16,7 +16,7 @@ public class MessagesConfiguration extends YmlConfiguration {
         addDefault("settings.cantStackEntity", "&cYou can't stack that entity");
         addDefault("settings.chatDisabled", "&cYou have chat disabled");
         addDefault("commands.settingNotFound", "&cThe setting specified wasn't found");
-        addDefault("commands.acceptedValues", "&cThe only accepted values are: on, off");
+        addDefault("commands.acceptedValues", "&cThe only accepted values are: on, off or integers");
         addDefault("commands.setSetting", "&aThe value of %name% &ahas been set to &e%value%");
         addDefault("commands.getSetting", "%name% &7- &e%value%");
     }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/configuration/MessagesConfiguration.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/configuration/MessagesConfiguration.java
@@ -11,12 +11,13 @@ public class MessagesConfiguration extends YmlConfiguration {
     protected void addDefaults() {
         addDefault("messages.sendMessageOnChange", true);
         addDefault("settings.noPermission", "&cYou don't have permissions to toggle this setting");
+        addDefault("settings.tooLowPermission", "&cYou don't have permissions to set this setting to that level. You may go up to %max%");
         addDefault("settings.selfStackerDisabled", "&cYou have stacker disabled");
         addDefault("settings.targetStackerDisabled", "&cThat player has stacker disabled");
         addDefault("settings.cantStackEntity", "&cYou can't stack that entity");
         addDefault("settings.chatDisabled", "&cYou have chat disabled");
         addDefault("commands.settingNotFound", "&cThe setting specified wasn't found");
-        addDefault("commands.acceptedValues", "&cThe only accepted values are: on, off or integers");
+        addDefault("commands.acceptedValues", "&cThe only accepted values are: on, off or integers <= %max%");
         addDefault("commands.setSetting", "&aThe value of %name% &ahas been set to &e%value%");
         addDefault("commands.getSetting", "%name% &7- &e%value%");
     }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/database/tables/PlayerSettingsTable.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/database/tables/PlayerSettingsTable.java
@@ -17,7 +17,7 @@ public class PlayerSettingsTable implements Supplier<Table> {
         // Define fields
         Field owner = new Field("owner", JDBCType.VARCHAR, "255");
         Field setting = new Field("settingName", JDBCType.VARCHAR, "255", new NotNullConstraint());
-        Field value = new Field("value", JDBCType.BOOLEAN, new NotNullConstraint());
+        Field value = new Field("value", JDBCType.INTEGER, new NotNullConstraint());
 
         // Add fields to table
         Table playerSettingsTable = new Table("player_settings");

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/database/tasks/LoadPlayerTask.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/database/tasks/LoadPlayerTask.java
@@ -31,10 +31,10 @@ public class LoadPlayerTask extends DatabaseTask {
             ResultSet resultSet = loadStatement.executeQuery();
             while (resultSet.next()) {
                 String settingName = resultSet.getString("settingName");
-                boolean enabled = resultSet.getBoolean("value");
+                int value = resultSet.getInt("value");
 
                 Setting setting = getPlugin().getSetting(settingName);
-                sPlayer.getSettingWatcher().setValue(setting, enabled, !new ConfigurationSetting(settingName).getExecuteOnJoin());
+                sPlayer.getSettingWatcher().setValue(setting, value, !new ConfigurationSetting(settingName).getExecuteOnJoin());
             }
         } catch (SQLException e) {
             getPlugin().getLogger().severe("Failed to load settings for player " + player.getName());

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/database/tasks/SavePlayerTask.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/database/tasks/SavePlayerTask.java
@@ -13,7 +13,7 @@ public class SavePlayerTask extends DatabaseTask {
     private static final String SAVE_QUERY = "INSERT INTO player_settings (owner, settingName, value)" +
             "VALUES (?, ?, ?)" +
             "ON DUPLICATE KEY " +
-            "UPDATE value=?";
+            "UPDATE value = VALUES(value)";
     private SPlayer player;
 
     public SavePlayerTask(PlayerSettings plugin, Connection connection, SPlayer player) {
@@ -31,8 +31,7 @@ public class SavePlayerTask extends DatabaseTask {
 
                 statement.setString(1, player.getUuid().toString());
                 statement.setString(2, rawName);
-                statement.setBoolean(3, player.getSettingWatcher().getValue(setting));
-                statement.setBoolean(4, player.getSettingWatcher().getValue(setting));
+                statement.setInt(3, player.getSettingWatcher().getValue(setting));
                 statement.executeUpdate();
             }
         } catch (SQLException e) {

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/listeners/ChatSettingListener.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/listeners/ChatSettingListener.java
@@ -20,7 +20,7 @@ public class ChatSettingListener implements Listener {
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         Player player = event.getPlayer();
         SPlayer sPlayer = plugin.getSPlayer(player.getUniqueId());
-        boolean hasChatEnabled = sPlayer.getSettingWatcher().getValue(plugin.getSetting("chat_setting"));
+        boolean hasChatEnabled = sPlayer.getSettingWatcher().getValue(plugin.getSetting("chat_setting")) == 1;
 
         if (!isAllowedWorld(player.getWorld().getName())) return;
         if (hasChatEnabled) {
@@ -35,6 +35,6 @@ public class ChatSettingListener implements Listener {
     }
 
     private boolean filterByChatDisabled(SPlayer sPlayer) {
-        return !sPlayer.getSettingWatcher().getValue(plugin.getSetting("chat_setting"));
+        return sPlayer.getSettingWatcher().getValue(plugin.getSetting("chat_setting")) != 1;
     }
 }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/listeners/StackerSettingListener.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/listeners/StackerSettingListener.java
@@ -29,7 +29,7 @@ public class StackerSettingListener implements Listener {
 
         if (!isAllowedWorld(player.getWorld().getName())) return;
 
-        if (!sPlayer.getSettingWatcher().getValue(stackerSetting)) {
+        if (sPlayer.getSettingWatcher().getValue(stackerSetting) != 1) {
             PlayerUtils.sendConfigMessage(player, "settings.selfStackerDisabled");
             return;
         }
@@ -47,7 +47,7 @@ public class StackerSettingListener implements Listener {
         Player clicked = (Player) event.getRightClicked();
         SPlayer sPlayerClicked = plugin.getSPlayer(clicked.getUniqueId());
 
-        if (!sPlayerClicked.getSettingWatcher().getValue(stackerSetting)) {
+        if (sPlayerClicked.getSettingWatcher().getValue(stackerSetting) != 1) {
             PlayerUtils.sendConfigMessage(player, "settings.targetStackerDisabled");
             return;
         }
@@ -90,7 +90,7 @@ public class StackerSettingListener implements Listener {
         SPlayer sPlayerClicked = plugin.getSPlayer(entity.getUniqueId());
         Setting stackerSetting = plugin.getSetting("stacker_setting");
 
-        if (!sPlayer.getSettingWatcher().getValue(stackerSetting)) return true;
-        return !sPlayerClicked.getSettingWatcher().getValue(stackerSetting);
+        if (sPlayer.getSettingWatcher().getValue(stackerSetting) != 1) return true;
+        return sPlayerClicked.getSettingWatcher().getValue(stackerSetting) != 1;
     }
 }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/menu/SettingsHolder.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/menu/SettingsHolder.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import me.limbo56.playersettings.PlayerSettings;
 import me.limbo56.playersettings.api.Setting;
 import me.limbo56.playersettings.settings.SPlayer;
+import me.limbo56.playersettings.utils.PlayerUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -34,7 +35,8 @@ public class SettingsHolder implements InventoryHolder {
             // (UX shows "will set to X" but will actually set to Y)
             int newValue = oldValue < 0 ? -oldValue : oldValue + 1;
             Setting configSetting = PlayerSettings.getPlugin().getSettingsRegistry().getSetting(setting.getRawName());
-            if (newValue > configSetting.getMaxValue())
+            int maxValue = Math.min(configSetting.getMaxValue(), PlayerUtils.getPermissionInt(player, "settings." + setting.getRawName()));
+            if (newValue > maxValue)
                 newValue = 0;
             String value = String.valueOf(newValue);
             player.performCommand("settings set " + setting.getRawName() + " " + value);

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/menu/SettingsHolder.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/menu/SettingsHolder.java
@@ -51,7 +51,9 @@ public class SettingsHolder implements InventoryHolder {
             SettingsMenu.openMenu(sPlayer, setting.getPage());
         };
         ItemStack itemStack = setting.getItem();
-        itemStack.setAmount(Math.max(1, Math.abs(oldValue)));
+        if (itemStack.getAmount() == 0) {
+            itemStack.setAmount(Math.max(1, Math.abs(oldValue)));
+        }
         this.renderItem(new CustomItem(setting.getSlot(), itemStack, playerConsumer));
         this.renderItem(new CustomItem(setting.getSlot() + 9, toggleItem, toggleConsumer));
     }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/menu/SettingsMenu.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/menu/SettingsMenu.java
@@ -78,7 +78,8 @@ public class SettingsMenu {
         }
 
         // Add glow if enabled
-        if (sPlayer.getSettingWatcher().getValue(setting)) {
+        int value = sPlayer.getSettingWatcher().getValue(setting);
+        if (value > 0) {
             toggleItem = new ConfigurationSetting("Enabled").getItem();
             addGlow(settingItem);
         } else {
@@ -86,7 +87,7 @@ public class SettingsMenu {
             removeGlow(settingItem);
         }
 
-        menu.renderSetting(setting, toggleItem);
+        menu.renderSetting(setting, toggleItem, value);
     }
 
     private static int getHighestPage() {

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/ConfigurationSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/ConfigurationSetting.java
@@ -84,8 +84,13 @@ public class ConfigurationSetting implements Setting {
     }
 
     @Override
-    public boolean getDefaultValue() {
-        return section.getBoolean("default");
+    public int getDefaultValue() {
+        return section.getInt("default");
+    }
+
+    @Override
+    public int getMaxValue() {
+        return Math.max(1, section.getInt("max"));
     }
 
     private YmlConfiguration getConfiguration() {

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/SettingsRegistry.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/SettingsRegistry.java
@@ -75,7 +75,8 @@ public class SettingsRegistry extends MapStore<String, Setting> {
 
             addToStore(configurationSetting);
             addCallback(configurationSetting, (setting, player, newValue) -> {
-                if (newValue) {
+                if (newValue > 0) {
+                    // that's not ok!
                     onEnable.ifPresent(strings -> strings.forEach(player::performCommand));
                 } else {
                     onDisable.ifPresent(strings -> strings.forEach(player::performCommand));
@@ -90,7 +91,7 @@ public class SettingsRegistry extends MapStore<String, Setting> {
         settingCallbacks.addToStore(getSetting(setting.getRawName()), settingCallback);
     }
 
-    private Setting getSetting(String rawName) {
+    public Setting getSetting(String rawName) {
         return getStored().get(rawName);
     }
 

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/SimpleSettingWatcher.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/SimpleSettingWatcher.java
@@ -57,13 +57,15 @@ public class SimpleSettingWatcher extends MapStore<Setting, Integer> implements 
         }
 
         getStored().replace(setting, value);
-        Runnable runnable = () -> Bukkit.getPluginManager().callEvent(new SettingUpdateEvent(getOwner(), setting, value));
+        Runnable runnable = () -> {
+            Bukkit.getPluginManager().callEvent(new SettingUpdateEvent(getOwner(), setting, value));
+            if (callbackMap.getStored().containsKey(setting) && !silent)
+                callbackMap.getStored().get(setting).notifyChange(setting, getOwner(), value);
+        };
         if (Bukkit.isPrimaryThread())
             runnable.run();
         else
             Bukkit.getScheduler().runTask(PlayerSettings.getPlugin(), runnable);
-        if (callbackMap.getStored().containsKey(setting) && !silent)
-            callbackMap.getStored().get(setting).notifyChange(setting, getOwner(), value);
     }
 
     @Override

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/SimpleSettingWatcher.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/SimpleSettingWatcher.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 
 import java.util.AbstractMap;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class SimpleSettingWatcher extends MapStore<Setting, Integer> implements SettingWatcher {
@@ -38,6 +39,20 @@ public class SimpleSettingWatcher extends MapStore<Setting, Integer> implements 
     public void setValue(Setting setting, int value, boolean silent) {
         if (!getOwner().hasPermission("settings." + setting.getRawName())) {
             PlayerUtils.sendConfigMessage(getOwner(), "settings.noPermission");
+            return;
+        }
+        int abs = Math.abs(value);
+        int maxAllowed = PlayerUtils.getPermissionInt(getOwner(), "settings." + setting.getRawName());
+        if (abs > 1 && abs > maxAllowed) {
+            Function<String, String> modifier = s -> s.replaceAll("%max%", String.valueOf(maxAllowed));
+            PlayerUtils.sendConfigMessage(getOwner(), "settings.tooLowPermission", modifier);
+            return;
+        }
+
+        int maxValue = PlayerSettings.getPlugin().getSettingsRegistry().getSetting(setting.getRawName()).getMaxValue();
+        if (abs > maxValue) {
+            Function<String, String> modifier = s -> s.replaceAll("%max%", String.valueOf(maxValue));
+            PlayerUtils.sendConfigMessage(getOwner(), "commands.acceptedValues", modifier);
             return;
         }
 

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/ChatSettings.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/ChatSettings.java
@@ -3,7 +3,6 @@ package me.limbo56.playersettings.settings.defined;
 import com.cryptomorin.xseries.XMaterial;
 import me.limbo56.playersettings.api.Setting;
 import me.limbo56.playersettings.utils.Item;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 public class ChatSettings implements Setting {
@@ -32,7 +31,12 @@ public class ChatSettings implements Setting {
     }
 
     @Override
-    public boolean getDefaultValue() {
-        return true;
+    public int getDefaultValue() {
+        return 1;
+    }
+
+    @Override
+    public int getMaxValue() {
+        return 1;
     }
 }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/FlySetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/FlySetting.java
@@ -4,7 +4,7 @@ import com.cryptomorin.xseries.XMaterial;
 import me.limbo56.playersettings.api.Setting;
 import me.limbo56.playersettings.api.SettingCallback;
 import me.limbo56.playersettings.utils.Item;
-import org.bukkit.Material;
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -35,15 +35,24 @@ public class FlySetting implements Setting {
     }
 
     @Override
-    public boolean getDefaultValue() {
-        return false;
+    public int getDefaultValue() {
+        return 0;
+    }
+
+    @Override
+    public int getMaxValue() {
+        return 10;
     }
 
     public static class FlySettingCallback implements SettingCallback {
         @Override
-        public void notifyChange(Setting setting, Player player, boolean newValue) {
-            player.setAllowFlight(newValue);
-            player.setFlying(newValue);
+        public void notifyChange(Setting setting, Player player, int newValue) {
+            GameMode gm = player.getGameMode();
+            if (gm != GameMode.CREATIVE && gm != GameMode.SPECTATOR) {
+                player.setAllowFlight(newValue > 0);
+                player.setFlying(newValue > 0);
+            }
+            player.setFlySpeed(Math.max(1, newValue) * 0.1F);
         }
     }
 }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/FlySetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/FlySetting.java
@@ -21,6 +21,7 @@ public class FlySetting implements Setting {
                 .name("&aFly")
                 .lore("&7Change the way you move")
                 .lore("&7around the map")
+                .amount(0)
                 .build();
     }
 

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
@@ -4,7 +4,6 @@ import com.cryptomorin.xseries.XMaterial;
 import me.limbo56.playersettings.api.Setting;
 import me.limbo56.playersettings.api.SettingCallback;
 import me.limbo56.playersettings.utils.Item;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -37,14 +36,19 @@ public class JumpSetting implements Setting {
     }
 
     @Override
-    public boolean getDefaultValue() {
-        return false;
+    public int getDefaultValue() {
+        return 0;
+    }
+
+    @Override
+    public int getMaxValue() {
+        return 1;
     }
 
     public static class JumpSettingCallback implements SettingCallback {
         @Override
-        public void notifyChange(Setting setting, Player player, boolean newValue) {
-            if (newValue) {
+        public void notifyChange(Setting setting, Player player, int newValue) {
+            if (newValue > 0) {
                 player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 99999, 2));
             } else {
                 player.removePotionEffect(PotionEffectType.JUMP);

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
@@ -42,14 +42,14 @@ public class JumpSetting implements Setting {
 
     @Override
     public int getMaxValue() {
-        return 1;
+        return 10;
     }
 
     public static class JumpSettingCallback implements SettingCallback {
         @Override
         public void notifyChange(Setting setting, Player player, int newValue) {
             if (newValue > 0) {
-                player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 99999, 2));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 99999, 1 + newValue));
             } else {
                 player.removePotionEffect(PotionEffectType.JUMP);
             }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
@@ -48,11 +48,10 @@ public class JumpSetting implements Setting {
     public static class JumpSettingCallback implements SettingCallback {
         @Override
         public void notifyChange(Setting setting, Player player, int newValue) {
+            player.removePotionEffect(PotionEffectType.JUMP);
             if (newValue > 0) {
                 // 3, 6, 9...
                 player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 99999, newValue * 3 - 1));
-            } else {
-                player.removePotionEffect(PotionEffectType.JUMP);
             }
         }
     }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
@@ -22,6 +22,7 @@ public class JumpSetting implements Setting {
                 .name("&aJump Boost")
                 .lore("&7Ever wanted to be a slime?")
                 .lore("&7Click this to feel like one")
+                .amount(0)
                 .build();
     }
 

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/JumpSetting.java
@@ -49,7 +49,8 @@ public class JumpSetting implements Setting {
         @Override
         public void notifyChange(Setting setting, Player player, int newValue) {
             if (newValue > 0) {
-                player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 99999, 1 + newValue));
+                // 3, 6, 9...
+                player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 99999, newValue * 3 - 1));
             } else {
                 player.removePotionEffect(PotionEffectType.JUMP);
             }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/SpeedSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/SpeedSetting.java
@@ -4,7 +4,6 @@ import com.cryptomorin.xseries.XMaterial;
 import me.limbo56.playersettings.api.Setting;
 import me.limbo56.playersettings.api.SettingCallback;
 import me.limbo56.playersettings.utils.Item;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -37,17 +36,24 @@ public class SpeedSetting implements Setting {
     }
 
     @Override
-    public boolean getDefaultValue() {
-        return false;
+    public int getDefaultValue() {
+        return 0;
+    }
+
+    @Override
+    public int getMaxValue() {
+        return 5;
     }
 
     public static class SpeedSettingCallback implements SettingCallback {
         @Override
-        public void notifyChange(Setting setting, Player player, boolean newValue) {
-            if (newValue) {
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 99999, 2));
+        public void notifyChange(Setting setting, Player player, int newValue) {
+            if (newValue > 0) {
+                player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 99999, 0));
+                player.setWalkSpeed(newValue == 1 ? 0.2F * 1.4F : newValue * 0.2F);
             } else {
                 player.removePotionEffect(PotionEffectType.SPEED);
+                player.setWalkSpeed(0.2F);
             }
         }
     }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/SpeedSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/SpeedSetting.java
@@ -22,6 +22,7 @@ public class SpeedSetting implements Setting {
                 .name("&aSpeed Boost")
                 .lore("&7Ever wonder what happens")
                 .lore("&7when you eat too much sugar?")
+                .amount(0)
                 .build();
     }
 

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/StackerSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/StackerSetting.java
@@ -3,7 +3,6 @@ package me.limbo56.playersettings.settings.defined;
 import com.cryptomorin.xseries.XMaterial;
 import me.limbo56.playersettings.api.Setting;
 import me.limbo56.playersettings.utils.Item;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 public class StackerSetting implements Setting {
@@ -34,7 +33,12 @@ public class StackerSetting implements Setting {
     }
 
     @Override
-    public boolean getDefaultValue() {
-        return false;
+    public int getDefaultValue() {
+        return 0;
+    }
+
+    @Override
+    public int getMaxValue() {
+        return 1;
     }
 }

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/VanishSetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/VanishSetting.java
@@ -5,7 +5,6 @@ import me.limbo56.playersettings.api.Setting;
 import me.limbo56.playersettings.api.SettingCallback;
 import me.limbo56.playersettings.utils.Item;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -38,14 +37,19 @@ public class VanishSetting implements Setting {
     }
 
     @Override
-    public boolean getDefaultValue() {
-        return false;
+    public int getDefaultValue() {
+        return 0;
+    }
+
+    @Override
+    public int getMaxValue() {
+        return 1;
     }
 
     public static class VanishSettingCallback implements SettingCallback {
         @Override
-        public void notifyChange(Setting setting, Player player, boolean newValue) {
-            if (newValue) {
+        public void notifyChange(Setting setting, Player player, int newValue) {
+            if (newValue > 0) {
                 player.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 99999, 1));
                 Bukkit.getOnlinePlayers().forEach(players -> players.hidePlayer(player));
             } else {

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/VisibilitySetting.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/settings/defined/VisibilitySetting.java
@@ -5,7 +5,6 @@ import me.limbo56.playersettings.api.Setting;
 import me.limbo56.playersettings.api.SettingCallback;
 import me.limbo56.playersettings.utils.Item;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -36,14 +35,19 @@ public class VisibilitySetting implements Setting {
     }
 
     @Override
-    public boolean getDefaultValue() {
-        return true;
+    public int getDefaultValue() {
+        return 1;
+    }
+
+    @Override
+    public int getMaxValue() {
+        return 1;
     }
 
     public static class VisibilitySettingCallback implements SettingCallback {
         @Override
-        public void notifyChange(Setting setting, Player player, boolean newValue) {
-            if (newValue) {
+        public void notifyChange(Setting setting, Player player, int newValue) {
+            if (newValue > 1) {
                 Bukkit.getOnlinePlayers().forEach(player::showPlayer);
             } else {
                 Bukkit.getOnlinePlayers().forEach(player::hidePlayer);

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/utils/ParseUtils.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/utils/ParseUtils.java
@@ -1,0 +1,21 @@
+package me.limbo56.playersettings.utils;
+
+
+public class ParseUtils {
+
+    public static Integer parseInt(String from) {
+        try {
+            return Integer.parseInt(from);
+        } catch (NumberFormatException ignored) {
+            switch (from.toLowerCase()) {
+                case "off":
+                    return 0;
+                case "on":
+                    return 1;
+                default:
+                    return null;
+            }
+        }
+    }
+
+}

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/utils/PlayerUtils.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/utils/PlayerUtils.java
@@ -59,7 +59,7 @@ public class PlayerUtils {
         permission = permission.toLowerCase() + ".";
         if (player.hasPermission(permission + "*"))
             return Integer.MAX_VALUE;
-        int computedLevel = 0;
+        int computedLevel = 1;
         for (PermissionAttachmentInfo pai : player.getEffectivePermissions()) {
             String playerPerm = pai.getPermission().toLowerCase();
             if (pai.getValue() && playerPerm.startsWith(permission)) {

--- a/playersettings-plugin/src/main/java/me/limbo56/playersettings/utils/PlayerUtils.java
+++ b/playersettings-plugin/src/main/java/me/limbo56/playersettings/utils/PlayerUtils.java
@@ -5,6 +5,7 @@ import me.limbo56.playersettings.api.SettingWatcher;
 import me.limbo56.playersettings.settings.SPlayer;
 import me.limbo56.playersettings.settings.SimpleSettingWatcher;
 import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
 
 import java.util.List;
 import java.util.function.Function;
@@ -52,5 +53,29 @@ public class PlayerUtils {
         return PlayerSettings.getPlugin().getSPlayerStore().getStored().values().stream()
                 .filter(filter)
                 .collect(Collectors.toList());
+    }
+
+    public static int getPermissionInt(Player player, String permission) {
+        permission = permission.toLowerCase() + ".";
+        if (player.hasPermission(permission + "*"))
+            return Integer.MAX_VALUE;
+        int computedLevel = 0;
+        for (PermissionAttachmentInfo pai : player.getEffectivePermissions()) {
+            String playerPerm = pai.getPermission().toLowerCase();
+            if (pai.getValue() && playerPerm.startsWith(permission)) {
+                try {
+                    String levelString = playerPerm.substring(permission.length());
+                    int level = Integer.parseInt(levelString); // throws NumberFormatException
+                    if (level < 0)
+                        throw new NumberFormatException("Level must be positive");
+                    if (level > computedLevel)
+                        computedLevel = level;
+                } catch (NumberFormatException ex) {
+                    PlayerSettings.getPlugin().getLogger().warning("Invalid permission level for " + player.getName() + ": " + playerPerm);
+                    PlayerSettings.getPlugin().getLogger().warning(ex.getLocalizedMessage());
+                }
+            }
+        }
+        return computedLevel;
     }
 }

--- a/playersettings-plugin/src/main/resources/plugin.yml
+++ b/playersettings-plugin/src/main/resources/plugin.yml
@@ -1,8 +1,8 @@
 name: PlayerSettings
 version: ${revision}
 main: me.limbo56.playersettings.PlayerSettings
-author: limbo56
+authors: [limbo56, BullCheat]
 prefix: "PlayerSettings"
 commands:
   settings:
-    description: Main command of the plugin.
+    description: Main command of PlayerSettings.

--- a/playersettings-plugin/src/test/java/TableTest.java
+++ b/playersettings-plugin/src/test/java/TableTest.java
@@ -16,7 +16,7 @@ public class TableTest {
                 " " +
                 "`settingName` VARCHAR(255) NOT NULL," +
                 " " +
-                "`value` BOOLEAN NOT NULL," + " " +
+                "`value` INTEGER NOT NULL," + " " +
                 "FOREIGN KEY (`uuid`) REFERENCES `players`(`uuid`)," +
                 " " +
                 "FOREIGN KEY (`settingName`) REFERENCES `defined`(`settingName`));";
@@ -32,7 +32,7 @@ public class TableTest {
         // Create fields
         Field uuidField = new Field("uuid", JDBCType.VARCHAR, "255", notNullConstraint);
         Field settingNameField = new Field("settingName", JDBCType.VARCHAR, "255", notNullConstraint);
-        Field valueField = new Field("value", JDBCType.BOOLEAN, notNullConstraint);
+        Field valueField = new Field("value", JDBCType.INTEGER, notNullConstraint);
 
         // Add table constraints
         playerSettingsTable.addConstraint(uuidFieldConstraint);

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>5.0.3</revision>
+        <revision>5.1.0</revision>
         <lombok.dependency.version>1.18.12</lombok.dependency.version>
         <lombok.plugin.version>1.18.10.0</lombok.plugin.version>
     </properties>


### PR DESCRIPTION
Add integer settings to handle multipliers for speed and fly.

Fly 1-10
Speed 1-5

Demo: https://youtu.be/GHS0TL1_DrE

This is by no means complete yet and there are still a couple fixme items I need to go through.
I would appreciate your feedback though.

Right now I am using a little hack to store values while settings are toggled off: negative values. I would like to get rid of this and add a proper value + status instead.

The migration from BOOLEAN to INTEGER should not create any problems on MySQL/MariaDB as BOOLEAN is an alias for INTEGER (or at least it is with InnoDB).