### PR TITLE
Release 6.3.4

### DIFF
--- a/bukkit/src/main/java/me/limbo56/playersettings/listeners/InventoryListener.java
+++ b/bukkit/src/main/java/me/limbo56/playersettings/listeners/InventoryListener.java
@@ -29,6 +29,7 @@ public class InventoryListener implements Listener {
     if (!(topInventory.getHolder() instanceof SettingsMenuHolder)) {
       return;
     }
+    event.setCancelled(true);
 
     // Check if item clicked is not null
     ItemStack itemStack = event.getCurrentItem();
@@ -43,7 +44,6 @@ public class InventoryListener implements Listener {
       return;
     }
 
-    event.setCancelled(true);
     item.executeClickAction(event.getClick(), holder.getOwner());
   }
 }

--- a/bukkit/src/main/java/me/limbo56/playersettings/listeners/StackerSettingListener.java
+++ b/bukkit/src/main/java/me/limbo56/playersettings/listeners/StackerSettingListener.java
@@ -1,5 +1,7 @@
 package me.limbo56.playersettings.listeners;
 
+import static me.limbo56.playersettings.settings.DefaultSettings.STACKER_SETTING;
+
 import me.limbo56.playersettings.PlayerSettings;
 import me.limbo56.playersettings.PlayerSettingsProvider;
 import me.limbo56.playersettings.api.event.SettingUpdateEvent;
@@ -7,6 +9,7 @@ import me.limbo56.playersettings.user.SettingUser;
 import me.limbo56.playersettings.util.Text;
 import me.limbo56.playersettings.util.Version;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,8 +17,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.util.Vector;
-
-import static me.limbo56.playersettings.settings.DefaultSettings.STACKER_SETTING;
 
 public class StackerSettingListener implements Listener {
   private static final PlayerSettings PLUGIN = PlayerSettingsProvider.getPlugin();
@@ -38,15 +39,17 @@ public class StackerSettingListener implements Listener {
       return;
     }
 
+    // Don't send message if stacker is disabled and the target is not a player
     SettingUser user = PLUGIN.getUserManager().getUser(player.getUniqueId());
     Entity clicked = event.getRightClicked();
     boolean hasStackerDisabled = !user.hasSettingEnabled(stackerSettingName);
+    boolean isTargetNotAnEntity = !(clicked instanceof LivingEntity);
     boolean isTargetNotAPlayer = !(clicked instanceof Player);
     boolean isTargetAnNPC = isMarkedAsNPC(clicked);
-    // Don't send message if stacker is disabled and the target is not a player
-    if (hasStackerDisabled && (isTargetNotAPlayer || isTargetAnNPC)) {
+    if (isTargetNotAnEntity || hasStackerDisabled && (isTargetNotAPlayer || isTargetAnNPC)) {
       return;
     }
+
     // Notify user that they have stacker disabled
     if (hasStackerDisabled) {
       Text.fromMessages("stacker.self-disabled")
@@ -54,6 +57,7 @@ public class StackerSettingListener implements Listener {
           .sendMessage(player, PLUGIN.getMessagesConfiguration().getMessagePrefix());
       return;
     }
+
     // Notify user that the target is not a player
     if (isTargetNotAPlayer || isTargetAnNPC) {
       Text.fromMessages("stacker.target-invalid-entity")

--- a/bukkit/src/main/java/me/limbo56/playersettings/settings/DefaultSettings.java
+++ b/bukkit/src/main/java/me/limbo56/playersettings/settings/DefaultSettings.java
@@ -77,7 +77,7 @@ public enum DefaultSettings {
       Constants.DEFAULT_VALUE_ALIASES),
   CHAT_SETTING(
       "chat-setting",
-      "&6Vanish",
+      "&6Chat",
       Chat.ITEM,
       1,
       1,

--- a/bukkit/src/main/java/me/limbo56/playersettings/util/PluginUpdater.java
+++ b/bukkit/src/main/java/me/limbo56/playersettings/util/PluginUpdater.java
@@ -1,9 +1,5 @@
 package me.limbo56.playersettings.util;
 
-import me.limbo56.playersettings.PlayerSettings;
-import me.limbo56.playersettings.PlayerSettingsProvider;
-import org.bukkit.entity.Player;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,6 +9,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import me.limbo56.playersettings.PlayerSettings;
+import me.limbo56.playersettings.PlayerSettingsProvider;
+import org.bukkit.entity.Player;
 
 public class PluginUpdater {
   private static final PlayerSettings PLUGIN = PlayerSettingsProvider.getPlugin();
@@ -45,7 +44,7 @@ public class PluginUpdater {
 
   private static String getUpdateMessage() {
     String latestVersionNumber = PluginUpdater.LATEST_VERSION.get();
-    if (LATEST_VERSION.equals("ERROR")) {
+    if (latestVersionNumber.equals("ERROR")) {
       return "&cAn error occurred while checking for updates!";
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <revision>6.3.3</revision>
+    <revision>6.3.4</revision>
   </properties>
 
   <modules>


### PR DESCRIPTION
**Changelog:**
- _Fixed_ Incorrect default name for the Chat setting
- _Fixed_ Issue where players could take items out of the settings inventory
- _Fixed_ Incorrect behavior of stacker setting sending invalid entity message
- _Fixed_ Plugin updater error message